### PR TITLE
Support non-default MATLAB installations via MATLAB_HOME envvar

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,8 @@ class _MatlabFinder(build_py):
     }
 
     DEFAULT_INSTALLS = {
-        'Darwin': f"/Applications/MATLAB_{MATLAB_REL}.app",
-        'Linux': f"/usr/local/MATLAB/{MATLAB_REL}"
+        'Darwin': f"{os.getenv('MATLAB_HOME', '/Applications')}/MATLAB_{MATLAB_REL}.app",
+        'Linux': f"{os.getenv('MATLAB_HOME', '/usr/local')}/MATLAB/{MATLAB_REL}"
     }
 
     arch = ''


### PR DESCRIPTION
The documentation mentions that it is possible to use MATLAB from a non-standard location:

> When MATLAB is not installed in the default location, the bin/*architecture* directory within the MATLAB root directory must be added to an environment variable. The path can be added to the environment variable within the shell startup configuration file (for example, .bashrc for bash shell or .tcshrc for tcsh).

However, the user has no way to tell the package where this installation is located.

This change adds support for reading environment variable `MATLAB_HOME` to be able to specify the directory containing the application, and defaults to `/Applications` on macOS and `/usr/local` on Linux when the variable is not defined.