### PR TITLE
Add Windows and macOS support to qualify_25a CI workflow

### DIFF
--- a/.github/workflows/qualify_25a.yml
+++ b/.github/workflows/qualify_25a.yml
@@ -14,29 +14,29 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-
-
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   test-python-engine:
     strategy:
       matrix:
         python: ["3.12", "3.11", "3.10", "3.9"]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v3.1.3
+        uses: actions/setup-python@v5.6.0
         with:
            python-version: ${{ matrix.python }}
 
       - name: Set up MATLAB
-        uses: matlab-actions/setup-matlab@v2
+        uses: matlab-actions/setup-matlab@v2.5.0
         with:
            release: R2025a
 
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v4.2.2
 
       - name: Run tests
-        uses: matlab-actions/run-tests@v1
+        uses: matlab-actions/run-tests@v2.1.1


### PR DESCRIPTION
This PR updates the `qualify_25a.yml` workflow to add support for running tests on Windows and macOS, in addition to the existing Ubuntu runs.

It also updates all GitHub Actions to their latest stable versions:
- 'setup-python@v5.6.0'
- 'setup-matlab@v2.5.0'
- 'checkout@v4.2.2'
- 'run-tests@v2.1.1'

The test matrix now runs across Python 3.12 to 3.9 on all three platforms.